### PR TITLE
Added TCP communication and extended blocks to video library 

### DIFF
--- a/AR_Drone_Target/blocks/videolib/ARdrone_legacy.m
+++ b/AR_Drone_Target/blocks/videolib/ARdrone_legacy.m
@@ -7,6 +7,15 @@ lib_name = 'ARdrone_video_lib';
 dev_video1_block_name = 'dev_video1_sfcn';
 dev_video2_block_name = 'dev_video2_sfcn';
 dev_printf_block_name = 'dev_printf_sfcn';
+dev_send1_block_name 		= 'dev_send1_sfcn';
+dev_receive1_block_name 	= 'dev_receive1_sfcn';
+dev_send2_block_name 		= 'dev_send2_sfcn';
+dev_receive2_block_name 	= 'dev_receive2_sfcn';
+dev_video1_send_block_name 			= 'dev_video1_send_sfcn';
+dev_video2_send_block_name 			= 'dev_video2_send_sfcn';
+dev_video1_send_thread_block_name 	= 'dev_video1_send_thread_sfcn';
+dev_video2_send_thread_block_name 	= 'dev_video2_send_thread_sfcn';
+
 if exist(lib_name, 'file')
 	load_system(lib_name);
 	set_param(lib_name, 'Lock', 'off')
@@ -14,6 +23,14 @@ if exist(lib_name, 'file')
 	delete_block([lib_name, '/', dev_video1_block_name]);
 	delete_block([lib_name, '/', dev_video2_block_name]);
 	delete_block([lib_name, '/', dev_printf_block_name]);
+    delete_block([lib_name, '/', dev_send1_block_name]);
+	delete_block([lib_name, '/', dev_receive1_block_name]);
+	delete_block([lib_name, '/', dev_send2_block_name]);
+	delete_block([lib_name, '/', dev_receive2_block_name]);
+	delete_block([lib_name, '/', dev_video1_send_block_name]);
+	delete_block([lib_name, '/', dev_video2_send_block_name]);	
+	delete_block([lib_name, '/', dev_video1_send_thread_block_name]);
+	delete_block([lib_name, '/', dev_video2_send_thread_block_name]);
 	catch
 	end
 else
@@ -77,6 +94,7 @@ dev_printf_def_sim.SourceFiles =  {'ARprintf.c'};
 dev_printf_def_sim.HeaderFiles = {'ARprintf.h'};
 % dev_video1_def_sim.Options.language =  'C++';
 
+
 %% Add necesarry specification to definition for code generation purpose
 dev_printf_def_codegen = dev_printf_def_sim;
 dev_printf_def_codegen.IncPaths = ...
@@ -88,10 +106,229 @@ dev_printf_def_codegen.SrcPaths = ...
 dev_printf_def_codegen.SourceFiles = ...
 	{'ARprintf.c'};
 
+
+	
+%% ------------------------------------------------------------------------------%
+%% 								ARdrone_send1_dev_block							 %
+%% ------------------------------------------------------------------------------%
+dev_send1_def_sim = legacy_code('initialize');
+dev_send1_def_sim.SFunctionName = dev_send1_block_name;
+dev_send1_def_sim.StartFcnSpec =		'void imageInitConnection1(int32 work1[1], int32 p1)';
+dev_send1_def_sim.OutputFcnSpec =		'double y1 = imageSend1(uint8 u1[1843200], int32 work1[1])';
+
+%%dev_send_def_sim.TerminateFcnSpec =	'void videoClose1(void)';
+dev_send1_def_sim.SampleTime = 'parameterized';
+dev_send1_def_sim.SourceFiles =  {'tcpLinuxClient.c'};
+dev_send1_def_sim.HeaderFiles = {'tcpLinuxClient.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_send1_def_codegen = dev_send1_def_sim;
+dev_send1_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_send1_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_send1_def_codegen.SourceFiles = ...
+	{'tcpLinuxClient.c'};
+	
+	
+%% ------------------------------------------------------------------------------%
+%% 								ARdrone_send2_dev_block							 %
+%% ------------------------------------------------------------------------------%
+dev_send2_def_sim = legacy_code('initialize');
+dev_send2_def_sim.SFunctionName = dev_send2_block_name;
+dev_send2_def_sim.StartFcnSpec =		'void imageInitConnection2(int32 work1[1], int32 p1)';
+dev_send2_def_sim.OutputFcnSpec =		'double y1 = imageSend2(uint8 u1[153600], int32 work1[1])';
+
+%%dev_send_def_sim.TerminateFcnSpec =	'void videoClose1(void)';
+dev_send2_def_sim.SampleTime = 'parameterized';
+dev_send2_def_sim.SourceFiles =  {'tcpLinuxClient.c'};
+dev_send2_def_sim.HeaderFiles = {'tcpLinuxClient.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_send2_def_codegen = dev_send2_def_sim;
+dev_send2_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_send2_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_send2_def_codegen.SourceFiles = ...
+	{'tcpLinuxClient.c'};
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+%% ------------------------------------------------------------------------------%
+%% 								ARdrone_receive1_dev_block							 %
+%% ------------------------------------------------------------------------------%
+dev_receive1_def_sim = legacy_code('initialize');
+dev_receive1_def_sim.SFunctionName = dev_receive1_block_name;
+dev_receive1_def_sim.StartFcnSpec =  'void initConnection1(int32 work1[1], int32 p1)';
+dev_receive1_def_sim.OutputFcnSpec ='double y2 = imageReceive1(uint8 y1[1843200], int32 work1[1])';
+
+dev_receive1_def_sim.TerminateFcnSpec =	'void closeConnection1(int32 work1[1])';
+dev_receive1_def_sim.SampleTime = 'parameterized';
+dev_receive1_def_sim.SourceFiles =  {'tcpWindowsServer.c'};
+dev_receive1_def_sim.HeaderFiles = {'tcpWindowsServer.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_receive1_def_codegen = dev_receive1_def_sim;
+dev_receive1_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_receive1_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_receive1_def_codegen.SourceFiles = ...
+	{'tcpWindowsServer.c'};
+	
+	
+%% ------------------------------------------------------------------------------%
+%% 								ARdrone_receive2_dev_block							 %
+%% ------------------------------------------------------------------------------%
+dev_receive2_def_sim = legacy_code('initialize');
+dev_receive2_def_sim.SFunctionName = dev_receive2_block_name;
+dev_receive2_def_sim.StartFcnSpec =  'void initConnection2(int32 work1[1], int32 p1)';
+dev_receive2_def_sim.OutputFcnSpec ='double y2 = imageReceive2(uint8 y1[153600], int32 work1[1])';
+
+dev_receive2_def_sim.TerminateFcnSpec =	'void closeConnection2(int32 work1[1])';
+dev_receive2_def_sim.SampleTime = 'parameterized';
+dev_receive2_def_sim.SourceFiles =  {'tcpWindowsServer.c'};
+dev_receive2_def_sim.HeaderFiles = {'tcpWindowsServer.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_receive2_def_codegen = dev_receive2_def_sim;
+dev_receive2_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_receive2_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_receive2_def_codegen.SourceFiles = ...
+	{'tcpWindowsServer.c'};
+	
+	
+	
+	
+	
+%% ------------------------------------------------------------------------------%
+%% 						ARdrone_video1_send_dev_block					 %
+%% ------------------------------------------------------------------------------%
+dev_video1_send_def_sim = legacy_code('initialize');
+dev_video1_send_def_sim.SFunctionName = dev_video1_send_block_name;
+dev_video1_send_def_sim.StartFcnSpec =		'void video1InitGrabSend(int32 work1[1], int32 p1, int32 p2, int32 p3)';
+dev_video1_send_def_sim.OutputFcnSpec =		'double y1 = video1GrabSend(int32 work1[1])';
+dev_video1_send_def_sim.TerminateFcnSpec =	'void video1CloseGrabSend(void)';
+dev_video1_send_def_sim.SampleTime = 'parameterized';
+dev_video1_send_def_sim.SourceFiles =  {'tcpVideoLinuxClient.c'};
+dev_video1_send_def_sim.HeaderFiles = {'tcpVideoLinuxClient.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video1_send_def_codegen = dev_video1_send_def_sim;
+dev_video1_send_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video1_send_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video1_send_def_codegen.SourceFiles = ...
+	{'tcpVideoLinuxClient.c'};
+
+	
+%% ------------------------------------------------------------------------------%
+%% 						ARdrone_video2_send_lock					 %
+%% ------------------------------------------------------------------------------%
+dev_video2_send_def_sim = legacy_code('initialize');
+dev_video2_send_def_sim.SFunctionName = dev_video2_send_block_name;
+dev_video2_send_def_sim.StartFcnSpec =		'void video2InitGrabSend(int32 work1[1], int32 p1, int32 p2, int32 p3)';
+dev_video2_send_def_sim.OutputFcnSpec =		'double y1 = video2GrabSend(int32 work1[1])';
+dev_video2_send_def_sim.TerminateFcnSpec =	'void video2CloseGrabSend(void)';
+dev_video2_send_def_sim.SampleTime = 'parameterized';
+dev_video2_send_def_sim.SourceFiles =  {'tcpVideoLinuxClient.c'};
+dev_video2_send_def_sim.HeaderFiles = {'tcpVideoLinuxClient.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video2_send_def_codegen = dev_video2_send_def_sim;
+dev_video2_send_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video2_send_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video2_send_def_codegen.SourceFiles = ...
+	{'tcpVideoLinuxClient.c'};
+	
+	
+		
+	
+	
+	
+		
+		
+		
+	
+%% ------------------------------------------------------------------------------%
+%% 						ARdrone_video1_send_thread_dev_block					 %
+%% ------------------------------------------------------------------------------%
+dev_video1_send_thread_def_sim = legacy_code('initialize');
+dev_video1_send_thread_def_sim.SFunctionName = dev_video1_send_thread_block_name;
+dev_video1_send_thread_def_sim.StartFcnSpec =		'void video1InitGrabSendMultiThread(int32 work1[1], int32 p1, int32 p2, int32 p3)';
+dev_video1_send_thread_def_sim.OutputFcnSpec =		'double y1 = video1GrabSendMultiThread(int32 work1[1])';
+dev_video1_send_thread_def_sim.TerminateFcnSpec =	'void video1CloseGrabSendMultiThread(void)';
+dev_video1_send_thread_def_sim.SampleTime = 'parameterized';
+dev_video1_send_thread_def_sim.SourceFiles =  {'tcpVideoLinuxClientMultiThread.c'};
+dev_video1_send_thread_def_sim.HeaderFiles = {'tcpVideoLinuxClientMultiThread.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video1_send_thread_def_codegen = dev_video1_send_thread_def_sim;
+dev_video1_send_thread_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video1_send_thread_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video1_send_thread_def_codegen.SourceFiles = ...
+	{'tcpVideoLinuxClientMultiThread.c'};
+
+	
+%% ------------------------------------------------------------------------------%
+%% 						ARdrone_video2_send_thread_dev_block					 %
+%% ------------------------------------------------------------------------------%
+dev_video2_send_thread_def_sim = legacy_code('initialize');
+dev_video2_send_thread_def_sim.SFunctionName = dev_video2_send_thread_block_name;
+dev_video2_send_thread_def_sim.StartFcnSpec =		'void video2InitGrabSendMultiThread(int32 work1[1], int32 p1, int32 p2, int32 p3)';
+dev_video2_send_thread_def_sim.OutputFcnSpec =		'double y1 = video2GrabSendMultiThread(int32 work1[1])';
+dev_video2_send_thread_def_sim.TerminateFcnSpec =	'void video2CloseGrabSendMultiThread(void)';
+dev_video2_send_thread_def_sim.SampleTime = 'parameterized';
+dev_video2_send_thread_def_sim.SourceFiles =  {'tcpVideoLinuxClientMultiThread.c'};
+dev_video2_send_thread_def_sim.HeaderFiles = {'tcpVideoLinuxClientMultiThread.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video2_send_thread_def_codegen = dev_video2_send_thread_def_sim;
+dev_video2_send_thread_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video2_send_thread_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video2_send_thread_def_codegen.SourceFiles = ...
+	{'tcpVideoLinuxClientMultiThread.c'};
+
+
+
+
 %% Generate S-funktions, tls files and rtwmakecfg file
-def_sim = [dev_video1_def_sim(:); dev_video2_def_sim(:); dev_printf_def_sim(:)];
+def_sim = [dev_video1_def_sim(:); dev_video2_def_sim(:); dev_printf_def_sim(:); dev_send1_def_sim(:) ; dev_receive1_def_sim(:) ; dev_send2_def_sim(:) ; dev_receive2_def_sim(:) ; dev_video1_send_def_sim(:) ; dev_video2_send_def_sim(:) ; dev_video1_send_thread_def_sim(:) ; dev_video2_send_thread_def_sim(:) ];
 % def_sim = dev_video1_def_sim(:);
-def_codegen = [dev_video1_def_codegen(:); dev_video2_def_codegen(:); dev_printf_def_codegen(:)];
+def_codegen = [dev_video1_def_codegen(:); dev_video2_def_codegen(:); dev_printf_def_codegen(:) ; dev_send1_def_codegen(:) ; dev_receive1_def_codegen(:) ; dev_send2_def_codegen(:) ; dev_receive2_def_codegen(:) ; dev_video1_send_def_codegen(:) ; dev_video2_send_def_codegen(:) ; dev_video1_send_thread_def_codegen(:) ; dev_video2_send_thread_def_codegen(:) ];
 legacy_code('sfcn_cmex_generate', def_sim)
 legacy_code('compile', def_sim)
 legacy_code('slblock_generate',def_codegen, lib_name);

--- a/AR_Drone_Target/blocks/videolib/ARdrone_legacy_old.m
+++ b/AR_Drone_Target/blocks/videolib/ARdrone_legacy_old.m
@@ -1,0 +1,107 @@
+%% Setting library and blocks names
+clc
+
+currentDir = pwd;
+
+lib_name = 'ARdrone_video_lib';
+dev_video1_block_name = 'dev_video1_sfcn';
+dev_video2_block_name = 'dev_video2_sfcn';
+dev_printf_block_name = 'dev_printf_sfcn';
+if exist(lib_name, 'file')
+	load_system(lib_name);
+	set_param(lib_name, 'Lock', 'off')
+	try
+	delete_block([lib_name, '/', dev_video1_block_name]);
+	delete_block([lib_name, '/', dev_video2_block_name]);
+	delete_block([lib_name, '/', dev_printf_block_name]);
+	catch
+	end
+else
+	new_system(lib_name, 'Library');
+	load_system(lib_name);
+end
+
+%% ARdrone_video1_dev_block
+dev_video1_def_sim = legacy_code('initialize');
+dev_video1_def_sim.SFunctionName = dev_video1_block_name;
+dev_video1_def_sim.StartFcnSpec =		'void videoInit1(void)';
+dev_video1_def_sim.OutputFcnSpec =		'videorabImage1(uint8 y1[1843200])';
+
+dev_video1_def_sim.TerminateFcnSpec =	'void videoClose1(void)';
+dev_video1_def_sim.SampleTime = 'parameterized';
+dev_video1_def_sim.SourceFiles =  {'video.c'};
+dev_video1_def_sim.HeaderFiles = {'video.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video1_def_codegen = dev_video1_def_sim;
+dev_video1_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video1_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video1_def_codegen.SourceFiles = ...
+	{'video.c'};
+
+%% ARdrone_video2_dev_block
+dev_video2_def_sim = legacy_code('initialize');
+dev_video2_def_sim.SFunctionName = dev_video2_block_name;
+dev_video2_def_sim.StartFcnSpec =		'void videoInit2(void)';
+dev_video2_def_sim.OutputFcnSpec =		'videorabImage2(uint8 y1[153600])';
+
+dev_video2_def_sim.TerminateFcnSpec =	'void videoClose2(void)';
+dev_video2_def_sim.SampleTime = 'parameterized';
+dev_video2_def_sim.SourceFiles =  {'video.c'};
+dev_video2_def_sim.HeaderFiles = {'video.h'};
+
+% Add necesarry specification to definition for code generation purpose
+dev_video2_def_codegen = dev_video2_def_sim;
+dev_video2_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_video2_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_video2_def_codegen.SourceFiles = ...
+	{'video.c'};
+
+%% ARprintf block
+dev_printf_def_sim = legacy_code('initialize');
+dev_printf_def_sim.SFunctionName = dev_printf_block_name;
+% dev_printf_def_sim.StartFcnSpec =		'void ARpintf_Init(void)';
+dev_printf_def_sim.OutputFcnSpec =		'ARpintf_Update(double u1)';
+
+% dev_printf_def_sim.TerminateFcnSpec =	'void ARpintf_Close(void)';
+dev_printf_def_sim.SampleTime = 'parameterized';
+dev_printf_def_sim.SourceFiles =  {'ARprintf.c'};
+dev_printf_def_sim.HeaderFiles = {'ARprintf.h'};
+% dev_video1_def_sim.Options.language =  'C++';
+
+%% Add necesarry specification to definition for code generation purpose
+dev_printf_def_codegen = dev_printf_def_sim;
+dev_printf_def_codegen.IncPaths = ...
+	{currentDir,...
+     '.'};
+dev_printf_def_codegen.SrcPaths = ...
+	{currentDir,...
+	 '.'};
+dev_printf_def_codegen.SourceFiles = ...
+	{'ARprintf.c'};
+
+%% Generate S-funktions, tls files and rtwmakecfg file
+def_sim = [dev_video1_def_sim(:); dev_video2_def_sim(:); dev_printf_def_sim(:)];
+% def_sim = dev_video1_def_sim(:);
+def_codegen = [dev_video1_def_codegen(:); dev_video2_def_codegen(:); dev_printf_def_codegen(:)];
+legacy_code('sfcn_cmex_generate', def_sim)
+legacy_code('compile', def_sim)
+legacy_code('slblock_generate',def_codegen, lib_name);
+legacy_code('sfcn_tlc_generate', def_codegen)
+legacy_code('rtwmakecfg_generate', def_codegen)
+
+%% Save exd exit
+save_system(lib_name);
+set_param(lib_name, 'EnableLBRepository','on');
+set_param(lib_name, 'Lock', 'on');
+% close_system(lib_name);
+% clear
+% EOF

--- a/AR_Drone_Target/blocks/videolib/tcpLinuxClient.c
+++ b/AR_Drone_Target/blocks/videolib/tcpLinuxClient.c
@@ -1,0 +1,197 @@
+#ifndef MATLAB_MEX_FILE
+
+//#include <signal.h>
+
+
+#endif //MATLAB_MEX_FILE
+
+
+
+#ifndef MATLAB_MEX_FILE
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <assert.h>
+#include <getopt.h> 
+#include <fcntl.h> 
+#include <unistd.h>
+#include <errno.h>
+#include <malloc.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <asm/types.h> 
+#include <linux/videodev2.h>
+#include <pthread.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+#endif //MATLAB_MEX_FILE
+
+#include "tcpLinuxClient.h"
+#define DEFAULT_BUFLEN 131072
+
+
+
+
+
+
+
+
+/******************************************
+			  TCP FUNCTIONS
+******************************************/
+
+#ifndef MATLAB_MEX_FILE
+int TCP_client_linux(char * ip ,long port)
+{						
+	void (*old_handler)(int);
+	int n; 
+	char *ptr, buffer[1024]; 
+	struct sockaddr_in addr; 
+
+	if((old_handler=signal(SIGPIPE,SIG_IGN))==SIG_ERR){ 
+		printf("signal error\n");
+		exit(1);
+	} 
+	int fd = socket(AF_INET,SOCK_STREAM,0);
+	
+	if(fd == -1){
+		printf("socket returned -1\n");
+		exit(1);
+	} 
+	
+	memset((void*)&addr,(int)'\0',sizeof(addr));
+
+	addr.sin_family=AF_INET; 
+	inet_aton(ip, &addr.sin_addr);
+	addr.sin_port=htons(port);
+  
+	int err;
+	int sndsize = DEFAULT_BUFLEN; 
+	int sockbufsize = 0;
+	int iSock = 1;
+	err = setsockopt( fd, IPPROTO_TCP, TCP_QUICKACK, (void *)&iSock, sizeof(iSock));
+	err = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sndsize, (int)sizeof(sndsize)); 
+	err = setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, (char *)&sndsize, (int)sizeof(sndsize)); 
+  
+	n=connect(fd,(struct sockaddr*)&addr,sizeof(addr));
+	if(n==-1) return -1;
+	
+	return fd;
+}
+
+int TCP_send_linux(int fd, char * message, int length)
+{
+	char * ptr = message;
+	int nleft,nwritten, n;
+	nwritten = 0;
+	nleft=length; 
+	while(nleft>0){
+		if(nleft < 8192) n=write(fd, ptr, nleft); 
+		else n=send(fd, ptr, 8192, 0); 
+		if(n==-1){
+			return -1;
+		}
+		nleft-=n; 
+		ptr+=n;
+		nwritten += n;
+	} 
+	return nwritten;
+}
+#endif //MATLAB_MEX_FILE
+
+
+
+
+
+
+
+
+
+/******************************************
+				VIDEO 1
+******************************************/
+
+void imageCloseConnection1(int fd){
+	#ifndef MATLAB_MEX_FILE
+
+	#endif //MATLAB_MEX_FILE
+}
+
+
+void imageInitConnection1(int * clientPortWorkVector, int port)
+{
+#ifndef MATLAB_MEX_FILE
+	clientPortWorkVector[0] = port;
+	return;
+#endif //MATLAB_MEX_FILE
+
+}
+
+
+double imageSend1(unsigned char* imageVectorInput, int * clientPortWorkVector)
+{
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	int s = TCP_client_linux("192.168.1.2", clientPortWorkVector[0]);
+	
+	if(s!=-1){
+		nbytes = TCP_send_linux(s,(char *) imageVectorInput, 1843200);
+		close(s);
+	} 
+		
+	return nbytes;
+#endif //MATLAB_MEX_FILE
+}
+
+
+
+
+
+/******************************************
+				VIDEO 2
+******************************************/
+
+void imageCloseConnection2(int fd){
+	#ifndef MATLAB_MEX_FILE
+
+	#endif //MATLAB_MEX_FILE
+}
+
+
+void imageInitConnection2(int * clientPortWorkVector, int port)
+{
+#ifndef MATLAB_MEX_FILE
+	clientPortWorkVector[0] = port;
+	return;
+#endif //MATLAB_MEX_FILE
+
+}
+
+
+double imageSend2(unsigned char* imageVectorInput, int * clientPortWorkVector)
+{
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	int s = TCP_client_linux("192.168.1.2", clientPortWorkVector[0]);
+	
+	if(s!=-1){
+		nbytes = TCP_send_linux(s,(char *) imageVectorInput, 153600);
+		close(s);
+	} 
+		
+	return nbytes;
+#endif //MATLAB_MEX_FILE
+}
+
+

--- a/AR_Drone_Target/blocks/videolib/tcpLinuxClient.h
+++ b/AR_Drone_Target/blocks/videolib/tcpLinuxClient.h
@@ -1,0 +1,25 @@
+#ifndef _TCP_LINUX_CLIENT_H
+#define _TCP_LINUX_CLIENT_H
+
+	#ifndef MATLAB_MEX_FILE
+
+		#include <stdio.h>
+		#include <stdlib.h>
+		#include <stdint.h>
+		#include<sys/types.h>
+
+		int 	TCP_client_linux(char * ip ,long port);
+		int 	TCP_send_linux(int fd, char * message, int length);
+
+		void 	imageCloseConnection1(int fd);
+		void 	imageInitConnection1(int * clientPortWorkVector, int port);
+		double 	imageSend1(unsigned char* imageVectorInput, int * clientPortWorkVector);
+
+		void imageCloseConnection2(int fd);
+		void imageInitConnection2(int * clientPortWorkVector, int port);
+		double imageSend2(unsigned char* imageVectorInput, int * clientPortWorkVector);
+
+	#endif //MATLAB_MEX_FILE
+
+#endif
+

--- a/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClient.c
+++ b/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClient.c
@@ -1,0 +1,707 @@
+/*
+    video.c - video driver
+
+    Copyright (C) 2011 Hugo Perquin - http://blog.perquin.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/
+
+#ifndef MATLAB_MEX_FILE
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <getopt.h> 
+#include <fcntl.h> 
+#include <unistd.h>
+#include <errno.h>
+#include <malloc.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <asm/types.h> 
+#include <linux/videodev2.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <signal.h>
+
+#endif //MATLAB_MEX_FILE
+
+#include "tcpVideoLinuxClientMultiThread.h"
+
+#ifndef MATLAB_MEX_FILE
+
+#define CLEAR(x) memset (&(x), 0, sizeof (x))
+#define DEFAULT_BUFLEN 131072
+
+#endif //MATLAB_MEX_FILE
+
+
+
+
+
+/*************************************
+		Auxiliar functions
+*************************************/
+
+#define DEFAULT_BUFLEN 131072
+int connect_TCPclient(char * ip ,long port)
+{						
+#ifndef MATLAB_MEX_FILE
+  void (*old_handler)(int);
+  int n; 
+  char *ptr, buffer[1024]; 
+
+  struct sockaddr_in addr; 
+
+	if((old_handler=signal(SIGPIPE,SIG_IGN))==SIG_ERR){ 
+		printf("signal error\n");
+		exit(1);
+	} 
+  int fd = socket(AF_INET,SOCK_STREAM,0);
+  //fcntl(fd, F_SETFL, O_NONBLOCK);
+
+  if(fd == -1){
+	  printf("socket returned -1\n");
+	  exit(1);
+  } 
+  memset((void*)&addr,(int)'\0',sizeof(addr));
+
+  addr.sin_family=AF_INET;
+  
+  inet_aton(ip, &addr.sin_addr);
+
+  addr.sin_port=htons(port);
+  int err;
+  int sndsize = DEFAULT_BUFLEN; 
+  int sockbufsize = 0; int size = sizeof(int); 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+  //printf("Buffer size before setsockopt %d\n", sockbufsize);
+  
+  int iSock = 1;
+  setsockopt( fd, IPPROTO_TCP, TCP_QUICKACK, (void *)&iSock, sizeof(iSock));
+  
+  err = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sndsize, (int)sizeof(sndsize)); 
+  
+  err = setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, (char *)&sndsize, (int)sizeof(sndsize)); 
+  
+  n=connect(fd,(struct sockaddr*)&addr,sizeof(addr));
+  if(n==-1) return -1;
+  
+  sockbufsize = 0; 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+ // printf("buffer%d\n", sockbufsize);
+  
+  sockbufsize = 0; 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+  //printf("Buffer size after connect %d\n", sockbufsize); 
+  
+  return fd;
+  #endif //MATLAB_MEX_FILE
+}
+
+
+
+int TCP_send(int fd, char * message, int length){
+	#ifndef MATLAB_MEX_FILE
+
+	char * ptr = message;
+	int nleft,nwritten, n;
+	nwritten = 0;
+	nleft=length; 
+	while(nleft>0){
+		if(nleft < 8192) n=write(fd, ptr, nleft); 
+		else n=send(fd, ptr, 8192, 0); 
+		if(n==-1){
+			return -1;
+		}//if(n<=0)exit(1);//error 
+		nleft-=n; 
+		ptr+=n;
+		nwritten += n;
+	 } 
+	 return nwritten;
+	#endif //MATLAB_MEX_FILE
+
+}
+
+	
+#ifndef MATLAB_MEX_FILE
+//return timestamp in seconds with microsecond resolution
+double util_timestamp()
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL); 
+  return (double)tv.tv_sec+((double)tv.tv_usec)/1000000;
+}
+
+#endif //MATLAB_MEX_FILE
+
+
+
+
+
+
+
+
+/*************************************
+				VIDEO 1
+*************************************/
+
+int cycleFlag = 0;
+
+void video1InitGrabSend(int * workPort, int port, int num_buffers, int runInitCycle)
+{
+#ifndef MATLAB_MEX_FILE
+	
+	workPort[0] = port;
+
+	vid1.device = (char*)"/dev/video1";
+	vid1.w=1280;
+	vid1.h=720;
+	vid1.n_buffers = num_buffers;
+	
+	img1 = (img_struct*)malloc(sizeof(img_struct));
+	img1->w=vid1.w;
+	img1->h=vid1.h;
+	img1->buf = (unsigned char*)malloc(vid1.h*vid1.w*2);
+		
+    struct v4l2_capability cap;
+    struct v4l2_format fmt;
+    unsigned int i;
+    enum v4l2_buf_type type;
+
+    extern int errno;
+
+	vid1.seq=0;
+	vid1.trigger=0;
+	if(vid1.n_buffers==0) vid1.n_buffers=num_buffers;
+	
+	vid1.fd = open(vid1.device, O_RDWR | O_NONBLOCK, 0);
+
+    if (ioctl(vid1.fd, VIDIOC_QUERYCAP, &cap) < 0) {
+		printf("ioctl() VIDIOC_QUERYCAP failed.\n");
+    }
+
+//     printf("2 driver = %s, card = %s, version = %d, capabilities = 0x%x\n", cap.driver, cap.card, cap.version, cap.capabilities);
+
+    CLEAR(fmt);
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width = vid1.w;	
+	fmt.fmt.pix.height = vid1.h;
+    fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_UYVY;
+    if (ioctl(vid1.fd, VIDIOC_S_FMT, &fmt) < 0) {
+		printf("ioctl() VIDIOC_S_FMT failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    struct v4l2_requestbuffers req;
+
+    CLEAR(req);
+    req.count = vid1.n_buffers;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = V4L2_MEMORY_MMAP;
+	
+    if (ioctl(vid1.fd, VIDIOC_REQBUFS, &req) < 0) {
+		// Catch errors slovak194
+		printf("ioctl() VIDIOC_REQBUFS failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    vid1.buffers = (buffer_struct*)calloc(vid1.n_buffers, sizeof(buffer_struct));
+
+    for (i = 0; i < vid1.n_buffers; ++i) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid1.fd, VIDIOC_QUERYBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QUERYBUF failed.\n");
+		}
+
+		vid1.buffers[i].length = buf.length;
+		printf("buffer%d.length=%d\n",i,buf.length);
+		vid1.buffers[i].buf = mmap(NULL, buf.length, PROT_READ|PROT_WRITE, MAP_SHARED, vid1.fd, buf.m.offset);
+
+		if (MAP_FAILED == vid1.buffers[i].buf) {
+			printf ("mmap() failed.\n");
+		}
+	}
+
+	for (i = 0; i < vid1.n_buffers; ++i) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid1.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("errno = %d\n", errno);
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+			exit(EXIT_FAILURE); 
+		}
+    }
+
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(vid1.fd, VIDIOC_STREAMON, &type)< 0) {
+		printf("ioctl() VIDIOC_STREAMON failed.\n");  
+    }
+	if(runInitCycle) cycleFlag = 0;
+	else cycleFlag = 1;
+	
+#endif //MATLAB_MEX_FILE
+}
+
+#ifndef MATLAB_MEX_FILE
+void video_GrabImage1() 
+{
+	fd_set fds;
+	struct timeval tv;
+	int r;
+
+	FD_ZERO(&fds);
+	FD_SET(vid1.fd, &fds);
+
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	r = select(vid1.fd + 1, &fds, NULL, NULL, &tv);
+
+	if (-1 == r) {
+		if (EINTR == errno)
+		printf("select err\n");
+	}
+
+	if (0 == r) {
+		fprintf(stderr, "select timeout\n");
+		exit(EXIT_FAILURE);
+	}
+	
+	struct v4l2_buffer buf;
+	CLEAR(buf);
+	
+	buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buf.memory = V4L2_MEMORY_MMAP;
+	
+	if (ioctl(vid1.fd, VIDIOC_DQBUF, &buf) < 0) {
+
+		printf("ioctl() VIDIOC_DQBUF failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	assert(buf.index < vid1.n_buffers);
+
+	vid1.seq++;	
+	vid1.img = img1;
+	vid1.img->timestamp = util_timestamp();
+	vid1.img->seq = vid1.seq;
+ 	
+	memcpy(vid1.img->buf, vid1.buffers[buf.index].buf, vid1.w*vid1.h*2);
+	
+	if (ioctl(vid1.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+	}
+}
+#endif //MATLAB_MEX_FILE
+
+
+#ifndef MATLAB_MEX_FILE
+void video_GrabImage1_initCycle() 
+{
+	fd_set fds;
+	struct timeval tv;
+	int r;
+	int count=0;
+
+	FD_ZERO(&fds);
+	FD_SET(vid1.fd, &fds);
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	
+	while(count<200){
+		
+		r = select(vid1.fd + 1, &fds, NULL, NULL, &tv);
+
+		if (-1 == r) {
+			break;
+		}
+		if (0 == r) {
+			break;
+		}
+		
+		struct v4l2_buffer buf;
+		CLEAR(buf);
+		
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		
+		if (ioctl(vid1.fd, VIDIOC_DQBUF, &buf) < 0) {
+
+			printf("ioctl() VIDIOC_DQBUF failed.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		assert(buf.index < vid1.n_buffers);
+
+		vid1.seq++;	
+		vid1.img = img1;
+		vid1.img->timestamp = util_timestamp();
+		vid1.img->seq = vid1.seq;
+		
+		memcpy(vid1.img->buf, vid1.buffers[buf.index].buf, vid1.w*vid1.h*2);
+		
+		if (ioctl(vid1.fd, VIDIOC_QBUF, &buf) < 0) {
+				printf("ioctl() VIDIOC_QBUF failed.\n");
+		}
+		
+		tv.tv_sec = 0;
+		tv.tv_usec = 100;
+		count++;
+	}
+	
+}
+#endif //MATLAB_MEX_FILE
+
+
+void video1CloseGrabSend(void)
+{
+#ifndef MATLAB_MEX_FILE
+
+	int i;
+    for (i = 0; i < vid1.n_buffers; ++i) {
+    	if (-1 == munmap(vid1.buffers[i].buf, vid1.buffers[i].length)) printf("munmap() failed.\n");
+    }
+    close(vid1.fd); 
+	
+#endif //MATLAB_MEX_FILE
+}
+
+
+double video1GrabSend(int * workPort)
+{	
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	
+	if( cycleFlag == 0 ){
+		video_GrabImage1_initCycle();
+		cycleFlag == 1;
+	}else{
+		video_GrabImage1();
+	}
+		
+	int fd = connect_TCPclient("192.168.1.2", workPort[0]);
+	if(fd!=-1){
+		double nbytes = TCP_send(fd,(char *) vid1.img->buf, 1843200);
+		close(fd);
+	} 
+	
+	return nbytes;
+
+#endif //MATLAB_MEX_FILE
+}
+	
+	
+
+
+	
+	
+	
+	
+	
+	
+	
+	
+/*************************************
+				VIDEO 2
+*************************************/
+
+int cycleFlag2 = 0;
+
+void video2InitGrabSend(int * workPort, int port, int num_buffers, int runInitCycle)
+{
+#ifndef MATLAB_MEX_FILE
+	
+	workPort[0] = port;
+	
+	vid2.device = (char*)"/dev/video2";
+	vid2.w=320;
+	vid2.h=240;
+	vid2.n_buffers = num_buffers;
+	
+	img2 = (img_struct*)malloc(sizeof(img_struct));
+	img2->w=vid2.w;
+	img2->h=vid2.h;
+	img2->buf = (unsigned char*)malloc(vid2.h*vid2.w*2);
+		
+    struct v4l2_capability cap;
+    struct v4l2_format fmt;
+    unsigned int i;
+    enum v4l2_buf_type type;
+
+    extern int errno;
+
+	vid2.seq=0;
+	vid2.trigger=0;
+	if(vid2.n_buffers==0) vid2.n_buffers=num_buffers;
+	
+	vid2.fd = open(vid2.device, O_RDWR | O_NONBLOCK, 0);
+
+    if (ioctl(vid2.fd, VIDIOC_QUERYCAP, &cap) < 0) {
+		printf("ioctl() VIDIOC_QUERYCAP failed.\n");
+    }
+
+//     printf("2 driver = %s, card = %s, version = %d, capabilities = 0x%x\n", cap.driver, cap.card, cap.version, cap.capabilities);
+
+    CLEAR(fmt);
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width = vid2.w;	
+	fmt.fmt.pix.height = vid2.h;
+    fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_UYVY;
+    if (ioctl(vid2.fd, VIDIOC_S_FMT, &fmt) < 0) {
+		printf("ioctl() VIDIOC_S_FMT failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    struct v4l2_requestbuffers req;
+
+    CLEAR(req);
+    req.count = vid2.n_buffers;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = V4L2_MEMORY_MMAP;
+	
+    if (ioctl(vid2.fd, VIDIOC_REQBUFS, &req) < 0) {
+		// Catch errors slovak194
+		printf("ioctl() VIDIOC_REQBUFS failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    vid2.buffers = (buffer_struct*)calloc(vid2.n_buffers, sizeof(buffer_struct));
+
+    for (i = 0; i < vid2.n_buffers; ++i) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid2.fd, VIDIOC_QUERYBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QUERYBUF failed.\n");
+		}
+
+		vid2.buffers[i].length = buf.length;
+		printf("buffer%d.length=%d\n",i,buf.length);
+		vid2.buffers[i].buf = mmap(NULL, buf.length, PROT_READ|PROT_WRITE, MAP_SHARED, vid2.fd, buf.m.offset);
+
+		if (MAP_FAILED == vid2.buffers[i].buf) {
+			printf ("mmap() failed.\n");
+		}
+	}
+
+	for (i = 0; i < vid2.n_buffers; ++i) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid2.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("errno = %d\n", errno);
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+			exit(EXIT_FAILURE); 
+		}
+    }
+
+	
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(vid2.fd, VIDIOC_STREAMON, &type)< 0) {
+		printf("ioctl() VIDIOC_STREAMON failed.\n");  
+    }
+	
+	if(runInitCycle) cycleFlag2 = 0;
+	else cycleFlag2 = 1;
+
+#endif //MATLAB_MEX_FILE
+}
+
+#ifndef MATLAB_MEX_FILE
+void video_GrabImage2() 
+{	
+	fd_set fds;
+	struct timeval tv;
+	int r;
+
+	FD_ZERO(&fds);
+	FD_SET(vid2.fd, &fds);
+
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	r = select(vid2.fd + 1, &fds, NULL, NULL, &tv);
+
+	if (-1 == r) {
+		if (EINTR == errno)
+		printf("select err\n");
+	}
+
+	if (0 == r) {
+		fprintf(stderr, "select timeout\n");
+		exit(EXIT_FAILURE);
+	}
+	
+	struct v4l2_buffer buf;
+	CLEAR(buf);
+	
+	buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buf.memory = V4L2_MEMORY_MMAP;
+	
+	if (ioctl(vid2.fd, VIDIOC_DQBUF, &buf) < 0) {
+
+		printf("ioctl() VIDIOC_DQBUF failed.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	assert(buf.index < vid2.n_buffers);
+
+	vid2.seq++;	
+	vid2.img = img2;
+	vid2.img->timestamp = util_timestamp();
+	vid2.img->seq = vid2.seq;
+ 	
+	memcpy(vid2.img->buf, vid2.buffers[buf.index].buf, vid2.w*vid2.h*2);
+	
+	if (ioctl(vid2.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+	}
+}
+#endif //MATLAB_MEX_FILE
+
+
+
+#ifndef MATLAB_MEX_FILE
+void video_GrabImage2_initCycle() 
+{
+	fd_set fds;
+	struct timeval tv;
+	int r;
+	int count=0;
+
+	FD_ZERO(&fds);
+	FD_SET(vid2.fd, &fds);
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	
+	while(count<200){
+		
+		r = select(vid2.fd + 1, &fds, NULL, NULL, &tv);
+
+		if (-1 == r) {
+			break;
+		}
+		if (0 == r) {
+			break;
+		}
+		
+		struct v4l2_buffer buf;
+		CLEAR(buf);
+		
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		
+		if (ioctl(vid2.fd, VIDIOC_DQBUF, &buf) < 0) {
+
+			printf("ioctl() VIDIOC_DQBUF failed.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		assert(buf.index < vid2.n_buffers);
+		
+		vid2.seq++;	
+		vid2.img = img2;
+		vid2.img->timestamp = util_timestamp();
+		vid2.img->seq = vid2.seq;
+	
+		memcpy(vid2.img->buf, vid2.buffers[buf.index].buf, vid2.w*vid2.h*2);
+		
+		if (ioctl(vid2.fd, VIDIOC_QBUF, &buf) < 0) {
+				printf("ioctl() VIDIOC_QBUF failed.\n");
+		}
+		
+		tv.tv_sec = 0;
+		tv.tv_usec = 100;
+		count++;
+	}
+	
+}
+#endif //MATLAB_MEX_FILE
+
+
+
+void video2CloseGrabSend(void)
+{
+#ifndef MATLAB_MEX_FILE
+
+	int i;
+    for (i = 0; i < vid2.n_buffers; ++i) {
+    	if (-1 == munmap(vid2.buffers[i].buf, vid2.buffers[i].length)) printf("munmap() failed.\n");
+    }
+    close(vid2.fd);
+	
+	
+#endif //MATLAB_MEX_FILE
+}
+
+
+double video2GrabSend(int * workPort)
+{	
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	
+	if( cycleFlag2 == 0 ){
+		video_GrabImage2_initCycle();
+		cycleFlag2 == 1;
+	}else{
+		video_GrabImage2();
+	}
+
+	int fd = connect_TCPclient("192.168.1.2", workPort[0]);
+	if(fd!=-1){
+		double nbytes = TCP_send(fd,(char *) vid2.img->buf, 153600);
+		close(fd);
+	} 
+	
+	return nbytes;
+
+#endif //MATLAB_MEX_FILE
+}
+	
+	
+
+
+
+
+

--- a/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClient.h
+++ b/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClient.h
@@ -1,0 +1,76 @@
+/*
+    video.h - video driver
+
+    Copyright (C) 2011 Hugo Perquin - http://blog.perquin.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/ 
+#ifndef _VIDEO_H
+#define _VIDEO_H
+
+#ifndef MATLAB_MEX_FILE
+
+typedef struct {
+    void * buf;
+    size_t length;
+}buffer_struct;
+
+typedef struct {
+	int seq;
+	double timestamp;
+	unsigned char* buf;
+	int w;
+	int h;
+}img_struct;
+
+typedef struct {
+	char *device;
+	int w;
+	int h;
+	int seq;
+	unsigned int n_buffers;
+	
+//private members	
+	int trigger;
+	img_struct *img;
+	buffer_struct * buffers;
+	int fd;
+}vid_struct;
+
+vid_struct vid1;
+img_struct* img1;
+
+vid_struct vid2;
+img_struct* img2;
+
+#endif //MATLAB_MEX_FILE
+
+void video1InitGrabSend(int * workPort, int port, int num_buffers, int runInitCycle);
+double video1GrabSend(int * workPort);
+void video1CloseGrabSend(void);
+
+void video2InitGrabSend(int * workPort, int port, int num_buffers, int runInitCycle);
+double video2GrabSend(int * workPort);
+void video2CloseGrabSend(void);
+
+
+//return timestamp in seconds with microsecond resolution
+double util_timestamp();
+int connect_TCPclient(char * ip ,long port);
+int TCP_send(int fd, char * message, int length);
+
+
+#endif

--- a/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClientMultiThread.c
+++ b/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClientMultiThread.c
@@ -1,0 +1,668 @@
+/*
+    video.c - video driver
+
+    Copyright (C) 2011 Hugo Perquin - http://blog.perquin.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/
+
+#ifndef MATLAB_MEX_FILE
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <getopt.h> 
+#include <fcntl.h> 
+#include <unistd.h>
+#include <errno.h>
+#include <malloc.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <asm/types.h> 
+#include <linux/videodev2.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <signal.h>
+
+#endif //MATLAB_MEX_FILE
+
+#include "tcpVideoLinuxClientMultiThread.h"
+
+#ifndef MATLAB_MEX_FILE
+
+#define CLEAR(x) memset (&(x), 0, sizeof (x))
+#define DEFAULT_BUFLEN 131072
+
+#endif //MATLAB_MEX_FILE
+
+
+int cycleFlag = 0;
+
+
+#ifndef MATLAB_MEX_FILE
+void video_GrabImage_initCycle(vid_struct* vid) 
+{
+	fd_set fds;
+	struct timeval tv;
+	int r;
+	int count=0;
+
+	FD_ZERO(&fds);
+	FD_SET(vid->fd, &fds);
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	
+	while(count<200){
+		
+		r = select(vid->fd + 1, &fds, NULL, NULL, &tv);
+
+		if (-1 == r) {
+			break;
+		}
+		if (0 == r) {
+			break;
+		}
+		
+		struct v4l2_buffer buf;
+		CLEAR(buf);
+		
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		
+		if (ioctl(vid->fd, VIDIOC_DQBUF, &buf) < 0) {
+
+			printf("ioctl() VIDIOC_DQBUF failed.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		assert(buf.index < vid->n_buffers);
+
+		vid->seq++;	
+		vid->img = img1;
+		vid->img->timestamp = util_timestamp();
+		vid->img->seq = vid->seq;
+		
+		memcpy(vid->img->buf, vid->buffers[buf.index].buf, vid->w*vid->h*2);
+		
+		if (ioctl(vid->fd, VIDIOC_QBUF, &buf) < 0) {
+				printf("ioctl() VIDIOC_QBUF failed.\n");
+		}
+		
+		tv.tv_sec = 0;
+		tv.tv_usec = 100;
+		count++;
+	}
+	printf("video_thread initial cycle ended\n");
+	return;
+}
+#endif //MATLAB_MEX_FILE
+
+/*************************************
+		Auxiliar functions
+*************************************/
+
+#ifndef MATLAB_MEX_FILE
+pthread_t video_thread;
+void *video_thread_main(void* data)
+{
+	vid_struct* vid = (vid_struct*)data;
+	printf("video_thread_main started\n");
+	struct v4l2_buffer buf;
+	
+	if(cycleFlag == 0){
+		video_GrabImage_initCycle(vid);	
+		cycleFlag = 1;
+	}
+	
+    for (;;) {
+		fd_set fds;
+		struct timeval tv;
+		int r;
+
+		FD_ZERO(&fds);
+		FD_SET(vid->fd, &fds);
+
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		r = select(vid->fd + 1, &fds, NULL, NULL, &tv);
+			
+		if (-1 == r) {
+			if (EINTR == errno) continue; 
+			printf("select err\n");
+		}
+
+		if (0 == r) {
+			fprintf(stderr, "select timeout\n");
+			exit(EXIT_FAILURE);
+		}
+		
+		unsigned int i;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		
+		if (ioctl(vid->fd, VIDIOC_DQBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_DQBUF failed.\n");
+			break;    
+		}
+
+		assert(buf.index < vid->n_buffers);
+
+		vid->seq++;
+		
+		if(vid->trigger) {
+			vid->img->timestamp = util_timestamp();
+			vid->img->seq = vid->seq;
+			memcpy(vid->img->buf, vid->buffers[buf.index].buf, 2*vid->w*vid->h);
+			vid->trigger=0;
+		}
+
+		if (ioctl(vid->fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+			break;    
+		}
+    }
+}
+#endif //MATLAB_MEX_FILE
+
+#ifndef MATLAB_MEX_FILE
+img_struct *video_CreateImage(vid_struct *vid)
+{
+	img_struct* img = (img_struct*)malloc(sizeof(img_struct));
+	img->w=vid->w;
+	img->h=vid->h;
+	img->buf = (unsigned char*)malloc(2 * vid->h*vid->w);
+	return img;
+}
+
+#endif //MATLAB_MEX_FILE
+
+
+
+#define DEFAULT_BUFLEN 131072
+
+int connect_TCPclient(char * ip ,long port)
+{						
+#ifndef MATLAB_MEX_FILE
+  void (*old_handler)(int);
+  int n; 
+  char *ptr, buffer[1024]; 
+
+  struct sockaddr_in addr; 
+
+	if((old_handler=signal(SIGPIPE,SIG_IGN))==SIG_ERR){ 
+		printf("signal error\n");
+		exit(1);
+	} 
+  int fd = socket(AF_INET,SOCK_STREAM,0);
+  //fcntl(fd, F_SETFL, O_NONBLOCK);
+
+  if(fd == -1){
+	  printf("socket returned -1\n");
+	  exit(1);
+  } 
+  memset((void*)&addr,(int)'\0',sizeof(addr));
+
+  addr.sin_family=AF_INET;
+  
+  inet_aton(ip, &addr.sin_addr);
+
+  addr.sin_port=htons(port);
+  int err;
+  int sndsize = DEFAULT_BUFLEN; 
+  int sockbufsize = 0; int size = sizeof(int); 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+  //printf("Buffer size before setsockopt %d\n", sockbufsize);
+  
+  int iSock = 1;
+  setsockopt( fd, IPPROTO_TCP, TCP_QUICKACK, (void *)&iSock, sizeof(iSock));
+  
+  err = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sndsize, (int)sizeof(sndsize)); 
+  
+  err = setsockopt(fd, IPPROTO_TCP, TCP_MAXSEG, (char *)&sndsize, (int)sizeof(sndsize)); 
+  
+  n=connect(fd,(struct sockaddr*)&addr,sizeof(addr));
+  if(n==-1) return -1;
+  
+  sockbufsize = 0; 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+ // printf("buffer%d\n", sockbufsize);
+  
+  sockbufsize = 0; 
+  err = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&sockbufsize, &size);
+  //printf("Buffer size after connect %d\n", sockbufsize); 
+  
+  return fd;
+  #endif //MATLAB_MEX_FILE
+}
+
+
+
+int TCP_send(int fd, char * message, int length){
+	#ifndef MATLAB_MEX_FILE
+
+	char * ptr = message;
+	int nleft,nwritten, n;
+	nwritten = 0;
+	nleft=length; 
+	while(nleft>0){
+		if(nleft < 8192) n=write(fd, ptr, nleft); 
+		else n=send(fd, ptr, 8192, 0); 
+		if(n==-1){
+			return -1;
+		}//if(n<=0)exit(1);//error 
+		nleft-=n; 
+		ptr+=n;
+		nwritten += n;
+	 } 
+	 return nwritten;
+	#endif //MATLAB_MEX_FILE
+
+}
+
+	
+#ifndef MATLAB_MEX_FILE
+//return timestamp in seconds with microsecond resolution
+double util_timestamp()
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL); 
+  return (double)tv.tv_sec+((double)tv.tv_usec)/1000000;
+}
+
+#endif //MATLAB_MEX_FILE
+
+
+
+
+
+
+
+/*************************************
+				VIDEO 1
+*************************************/
+
+void video1InitGrabSendMultiThread(int * workPort, int port, int num_buffers, int runInitCycle)
+{
+#ifndef MATLAB_MEX_FILE
+	
+	workPort[0] = port;
+	
+	char command[255];
+	vid1.device = (char*)"/dev/video1";
+	vid1.w=1280;
+	vid1.h=720;
+	vid1.n_buffers = num_buffers;
+	
+	img1 = video_CreateImage(&vid1);
+		
+    struct v4l2_capability cap;
+    struct v4l2_format fmt;
+    unsigned int i;
+    enum v4l2_buf_type type;
+
+    extern int errno;
+
+	vid1.seq=0;
+	vid1.trigger=0;
+	if(vid1.n_buffers==0) vid1.n_buffers=num_buffers;
+	
+	vid1.fd = open(vid1.device, O_RDWR | O_NONBLOCK, 0);
+
+    if (ioctl(vid1.fd, VIDIOC_QUERYCAP, &cap) < 0) {
+		printf("ioctl() VIDIOC_QUERYCAP failed.\n");
+    }
+
+//     printf("2 driver = %s, card = %s, version = %d, capabilities = 0x%x\n", cap.driver, cap.card, cap.version, cap.capabilities);
+
+	 struct v4l2_fmtdesc fmtdesc;
+        memset(&fmtdesc,0,sizeof(fmtdesc));
+        fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        while (ioctl(vid1.fd,VIDIOC_ENUM_FMT,&fmtdesc) == 0)
+        {    
+            printf("%s\n", fmtdesc.description);
+            fmtdesc.index++;
+        }
+		
+    CLEAR(fmt);
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width =vid1.w; 
+	fmt.fmt.pix.height =vid1.h;
+    fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_UYVY;
+    if (ioctl(vid1.fd, VIDIOC_S_FMT, &fmt) < 0) {
+		printf("ioctl() VIDIOC_S_FMT failed.\n");
+		exit(EXIT_FAILURE);
+    }
+		
+    struct v4l2_requestbuffers req;
+
+    CLEAR(req);
+    req.count = vid1.n_buffers;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = V4L2_MEMORY_MMAP;
+	
+    if (ioctl(vid1.fd, VIDIOC_REQBUFS, &req) < 0) {
+		// Catch errors slovak194
+		printf("ioctl() VIDIOC_REQBUFS failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    vid1.buffers = (buffer_struct*)calloc(vid1.n_buffers, sizeof(buffer_struct));
+
+    for (i = 0; i < vid1.n_buffers; i++) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid1.fd, VIDIOC_QUERYBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QUERYBUF failed.\n");
+		}
+
+		vid1.buffers[i].length = buf.length;
+		printf("buffer%d.length=%d\n",i,buf.length);
+		vid1.buffers[i].buf = mmap(NULL, buf.length, PROT_READ|PROT_WRITE, MAP_SHARED, vid1.fd, buf.m.offset);
+
+		if (MAP_FAILED == vid1.buffers[i].buf) {
+			printf ("mmap() failed.\n");
+		}
+	}
+
+	for (i = 0; i < vid1.n_buffers; i++) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid1.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("errno = %d\n", errno);
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+			exit(EXIT_FAILURE); 
+		}
+    }
+
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(vid1.fd, VIDIOC_STREAMON, &type)< 0) {
+		printf("ioctl() VIDIOC_STREAMON failed.\n");  
+    }
+	
+	if(runInitCycle) cycleFlag = 0;
+	else cycleFlag = 1;
+	
+	//start video thread 
+	int rc = pthread_create(&video_thread, NULL, video_thread_main, (void *) &vid1); 
+	if(rc) {
+		printf("ctl_Init: Return code from pthread_create(mot_thread) is %d\n", rc);
+		exit(202);
+	}
+	
+	
+
+	return;
+
+#endif //MATLAB_MEX_FILE
+}
+
+#ifndef MATLAB_MEX_FILE
+pthread_mutex_t video_grab_mutex = PTHREAD_MUTEX_INITIALIZER; 
+
+void video_GrabImageMultiThread(vid_struct *vid, img_struct *img) 
+{
+	pthread_mutex_lock(&video_grab_mutex);
+	vid->img = img;
+	vid->trigger=1;
+	while(vid->trigger) pthread_yield();
+	pthread_mutex_unlock(&video_grab_mutex);
+}
+#endif //MATLAB_MEX_FILE
+
+
+void video1CloseGrabSendMultiThread(void)
+{
+#ifndef MATLAB_MEX_FILE
+
+	int i;
+    for (i = 0; i < vid1.n_buffers; ++i) {
+    	if (-1 == munmap(vid1.buffers[i].buf, vid1.buffers[i].length)) printf("munmap() failed.\n");
+    }
+    close(vid1.fd); 
+	
+#endif //MATLAB_MEX_FILE
+}
+
+
+double video1GrabSendMultiThread(int * workPort)
+{	
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	
+	video_GrabImageMultiThread(&vid1, img1);
+
+	int fd = connect_TCPclient("192.168.1.2", workPort[0]);
+	if(fd!=-1){
+		double nbytes = TCP_send(fd,(char *) img1->buf, 1843200);
+		close(fd);
+	} 
+	
+	return nbytes;
+
+#endif //MATLAB_MEX_FILE
+}
+	
+	
+
+
+	
+	
+	
+	
+	
+	
+
+/*************************************
+				VIDEO 2
+*************************************/
+
+void video2InitGrabSendMultiThread(int * workPort, int port, int num_buffers, int runInitCycle)
+{
+#ifndef MATLAB_MEX_FILE
+	
+	workPort[0] = port;
+	
+	char command[255];
+	vid2.device = (char*)"/dev/video2";
+	vid2.w=320;
+	vid2.h=240;
+	vid2.n_buffers = num_buffers;
+	
+	img2 = video_CreateImage(&vid2);
+		
+    struct v4l2_capability cap;
+    struct v4l2_format fmt;
+    unsigned int i;
+    enum v4l2_buf_type type;
+
+    extern int errno;
+
+	vid2.seq=0;
+	vid2.trigger=0;
+	if(vid2.n_buffers==0) vid2.n_buffers=num_buffers;
+	
+	vid2.fd = open(vid2.device, O_RDWR | O_NONBLOCK, 0);
+
+    if (ioctl(vid2.fd, VIDIOC_QUERYCAP, &cap) < 0) {
+		printf("ioctl() VIDIOC_QUERYCAP failed.\n");
+    }
+
+//     printf("2 driver = %s, card = %s, version = %d, capabilities = 0x%x\n", cap.driver, cap.card, cap.version, cap.capabilities);
+
+	 struct v4l2_fmtdesc fmtdesc;
+        memset(&fmtdesc,0,sizeof(fmtdesc));
+        fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        while (ioctl(vid2.fd,VIDIOC_ENUM_FMT,&fmtdesc) == 0)
+        {    
+            printf("%s\n", fmtdesc.description);
+            fmtdesc.index++;
+        }
+		
+    CLEAR(fmt);
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width =vid2.w; 
+	fmt.fmt.pix.height =vid2.h;
+    fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_UYVY;
+    if (ioctl(vid2.fd, VIDIOC_S_FMT, &fmt) < 0) {
+		printf("ioctl() VIDIOC_S_FMT failed.\n");
+		exit(EXIT_FAILURE);
+    }
+		
+    struct v4l2_requestbuffers req;
+
+    CLEAR(req);
+    req.count = vid2.n_buffers;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = V4L2_MEMORY_MMAP;
+	
+    if (ioctl(vid2.fd, VIDIOC_REQBUFS, &req) < 0) {
+		// Catch errors slovak194
+		printf("ioctl() VIDIOC_REQBUFS failed.\n");
+		exit(EXIT_FAILURE);
+    }
+
+    vid2.buffers = (buffer_struct*)calloc(vid2.n_buffers, sizeof(buffer_struct));
+
+    for (i = 0; i < vid2.n_buffers; i++) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid2.fd, VIDIOC_QUERYBUF, &buf) < 0) {
+			printf("ioctl() VIDIOC_QUERYBUF failed.\n");
+		}
+
+		vid2.buffers[i].length = buf.length;
+		printf("buffer%d.length=%d\n",i,buf.length);
+		vid2.buffers[i].buf = mmap(NULL, buf.length, PROT_READ|PROT_WRITE, MAP_SHARED, vid2.fd, buf.m.offset);
+
+		if (MAP_FAILED == vid2.buffers[i].buf) {
+			printf ("mmap() failed.\n");
+		}
+	}
+
+	for (i = 0; i < vid2.n_buffers; i++) {
+		struct v4l2_buffer buf;
+
+		CLEAR(buf);
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		if (ioctl(vid2.fd, VIDIOC_QBUF, &buf) < 0) {
+			printf("errno = %d\n", errno);
+			printf("ioctl() VIDIOC_QBUF failed.\n");
+			exit(EXIT_FAILURE); 
+		}
+    }
+
+    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(vid2.fd, VIDIOC_STREAMON, &type)< 0) {
+		printf("ioctl() VIDIOC_STREAMON failed.\n");  
+    }
+	
+	if(runInitCycle) cycleFlag = 0;
+	else cycleFlag = 1;
+	
+	//start video thread 
+	int rc = pthread_create(&video_thread, NULL, video_thread_main, (void *) &vid2); 
+	if(rc) {
+		printf("ctl_Init: Return code from pthread_create(mot_thread) is %d\n", rc);
+		exit(202);
+	}
+
+	return;
+
+#endif //MATLAB_MEX_FILE
+}
+
+#ifndef MATLAB_MEX_FILE
+pthread_mutex_t video_grab_mutex2 = PTHREAD_MUTEX_INITIALIZER; 
+
+void video_GrabImage2MultiThread(vid_struct *vid, img_struct *img) 
+{
+	pthread_mutex_lock(&video_grab_mutex2);
+	vid->img = img;
+	vid->trigger=1;
+	while(vid->trigger) pthread_yield();
+	pthread_mutex_unlock(&video_grab_mutex2);
+}
+#endif //MATLAB_MEX_FILE
+
+
+void video2CloseGrabSendMultiThread(void)
+{
+#ifndef MATLAB_MEX_FILE
+
+	int i;
+    for (i = 0; i < vid2.n_buffers; ++i) {
+    	if (-1 == munmap(vid2.buffers[i].buf, vid2.buffers[i].length)) printf("munmap() failed.\n");
+    }
+    close(vid2.fd); 
+	
+#endif //MATLAB_MEX_FILE
+}
+
+
+double video2GrabSendMultiThread(int * workPort)
+{	
+#ifndef MATLAB_MEX_FILE
+	double nbytes = 0;
+	
+	video_GrabImage2MultiThread(&vid2, img2);
+
+	int fd = connect_TCPclient("192.168.1.2", workPort[0]);
+	if(fd!=-1){
+		double nbytes = TCP_send(fd,(char *) img2->buf, 153600);
+		close(fd);
+	} 
+	
+	return nbytes;
+
+#endif //MATLAB_MEX_FILE
+}
+	
+	
+
+
+
+
+

--- a/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClientMultiThread.h
+++ b/AR_Drone_Target/blocks/videolib/tcpVideoLinuxClientMultiThread.h
@@ -1,0 +1,76 @@
+/*
+    video.h - video driver
+
+    Copyright (C) 2011 Hugo Perquin - http://blog.perquin.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA 02110-1301 USA.
+*/ 
+#ifndef _VIDEO_H
+#define _VIDEO_H
+
+#ifndef MATLAB_MEX_FILE
+
+typedef struct {
+    void * buf;
+    size_t length;
+}buffer_struct;
+
+typedef struct {
+	int seq;
+	double timestamp;
+	unsigned char* buf;
+	int w;
+	int h;
+}img_struct;
+
+typedef struct {
+	char *device;
+	int w;
+	int h;
+	int seq;
+	unsigned int n_buffers;
+	
+//private members	
+	int trigger;
+	img_struct *img;
+	buffer_struct * buffers;
+	int fd;
+}vid_struct;
+
+vid_struct vid1;
+img_struct* img1;
+
+vid_struct vid2;
+img_struct* img2;
+
+#endif //MATLAB_MEX_FILE
+
+void video1InitGrabSendMultiThread(int * workPort, int port, int num_buffers, int runInitCycle);
+double video1GrabSendMultiThread(int * workPort);
+void video1CloseGrabSendMultiThread(void);
+
+void video2InitGrabSendMultiThread(int * workPort, int port, int num_buffers, int runInitCycle);
+double video2GrabSendMultiThread(int * workPort);
+void video2CloseGrabSendMultiThread(void);
+
+
+//return timestamp in seconds with microsecond resolution
+double util_timestamp();
+int connect_TCPclient(char * ip ,long port);
+int TCP_send(int fd, char * message, int length);
+
+
+#endif

--- a/AR_Drone_Target/blocks/videolib/tcpWindowsServer.c
+++ b/AR_Drone_Target/blocks/videolib/tcpWindowsServer.c
@@ -1,0 +1,241 @@
+#undef UNICODE
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <signal.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#pragma comment (lib, "Ws2_32.lib")
+#include "mex.h"
+
+#define DEFAULT_BUFLEN 131072
+
+#include "tcpWindowsServer.h"
+
+
+/******************************************
+			  TCP FUNCTIONS
+******************************************/
+
+static CHAR * getLastErrorText(CHAR *pBuf, ULONG bufSize)
+{
+    DWORD retSize;
+    LPTSTR pTemp=NULL;
+
+    retSize=FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|
+                          FORMAT_MESSAGE_FROM_SYSTEM|
+                          FORMAT_MESSAGE_ARGUMENT_ARRAY,
+                          NULL,
+                          GetLastError(),
+                          LANG_NEUTRAL,
+                          (LPTSTR)&pTemp,
+                          0,
+                          NULL);
+     if (!retSize || pTemp == NULL) {
+          pBuf[0]='\0';
+     } else {
+          pTemp[strlen(pTemp)-2]='\0'; //remove cr and newline character
+          sprintf(pBuf,"%0.*s (0x%x)",bufSize-16,pTemp,GetLastError());
+          LocalFree((HLOCAL)pTemp);
+     }
+     return(pBuf);
+}
+
+
+ 
+char err[255];
+int open_TCPserver(int tport)
+{
+
+
+	WSADATA wsaData;
+    int iResult;
+    SOCKET ListenSocket = INVALID_SOCKET;
+    SOCKET ClientSocket = INVALID_SOCKET;
+    struct addrinfo *result = NULL;
+    struct addrinfo hints;
+ 
+    // Initialize Winsock
+    iResult = WSAStartup(MAKEWORD(2,2), &wsaData);
+    if (iResult != 0) {
+        sprintf(err, "WSAStartup failed with error: %d\n", iResult);
+        return -1;
+    }
+	
+	
+    ZeroMemory(&hints, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags = AI_PASSIVE;
+
+    // Resolve the server address and port
+	char sport[10];
+	_itoa(tport, sport, 10);
+    iResult = getaddrinfo(NULL, sport, &hints, &result);
+    if ( iResult != 0 ) {
+        sprintf(err, "WSAStartup failed with error: %d\n", iResult);
+        WSACleanup();
+        return -1;
+    }
+
+	
+    // Create a SOCKET for connecting to server
+    ListenSocket = socket(result->ai_family, result->ai_socktype, result->ai_protocol);
+    if (ListenSocket == INVALID_SOCKET) {
+        sprintf(err, "socket failed with error: %ld\n", WSAGetLastError());
+        freeaddrinfo(result);
+        WSACleanup();
+        return -1;
+    }
+
+	
+    // Setup the TCP listening socket
+    iResult = bind( ListenSocket, result->ai_addr, (int)result->ai_addrlen);
+    if (iResult == SOCKET_ERROR) {
+        sprintf(err, "bind failed with error: %d\n", WSAGetLastError());
+        freeaddrinfo(result);
+        closesocket(ListenSocket);
+        WSACleanup();
+        return -1;
+    }
+
+    freeaddrinfo(result);
+
+    iResult = listen(ListenSocket, SOMAXCONN);
+    if (iResult == SOCKET_ERROR) {
+        sprintf(err, "listen failed with error: %d\n", WSAGetLastError());
+        closesocket(ListenSocket);
+        WSACleanup();
+        return -1;
+    }
+
+	return (int) ListenSocket;
+}
+
+
+int accept_TCPserver(SOCKET ListenSocket)
+{
+	
+	SOCKET ClientSocket = INVALID_SOCKET;
+
+	ClientSocket = accept(ListenSocket, NULL, NULL);
+    if (ClientSocket == INVALID_SOCKET) {
+        sprintf(err, "accept failed with error: %d\n", WSAGetLastError());
+        closesocket(ListenSocket);
+        WSACleanup();
+        return -1;
+    }
+	
+	int sndsize = DEFAULT_BUFLEN; 
+	int error = setsockopt(ClientSocket, SOL_SOCKET, SO_RCVBUF, (char *)&sndsize, (int)sizeof(sndsize));
+	
+	error = setsockopt(ClientSocket, SOL_SOCKET, SO_RCVBUF, (char *)&sndsize, (int)sizeof(sndsize)); 
+	
+	return ClientSocket;
+	
+}
+
+
+int TCP_receive(int fd, char *buffer, int bytes)
+{
+
+	int iResult;
+    char recvbuf[DEFAULT_BUFLEN];
+    int recvbuflen = DEFAULT_BUFLEN;
+	int nRead = 0;
+	int nleft = bytes;
+	
+	do {
+        iResult = recv(fd, recvbuf, recvbuflen, 0);
+        if ( iResult > 0 ){
+			memcpy(buffer+nRead, recvbuf, iResult);
+			nRead += iResult;
+			nleft -= iResult;
+			memset(recvbuf,'\0',recvbuflen);
+		} else if ( iResult == 0 )
+            break;
+        else
+            printf("recv failed: %d\n", WSAGetLastError());
+    } while( nleft > 0);
+
+	return nRead;
+}
+
+
+
+
+
+
+
+
+
+/******************************************
+				VIDEO 1
+******************************************/
+
+
+void closeConnection1(int * serverFdWorkVector)
+{
+	closesocket(serverFdWorkVector[0]);
+	return;
+}
+
+
+void initConnection1(int * serverFdWorkVector, int port){
+	int fd = open_TCPserver(port);
+	serverFdWorkVector[0] = fd; 
+	return;
+}
+
+
+double imageReceive1(uint8_t y[1843200], int * workFd){
+
+	double nbytes = 0;
+	
+	int fd = accept_TCPserver( (SOCKET) workFd[0]); 
+	nbytes = TCP_receive(fd, y, 1843200); 
+	closesocket(fd);
+	
+	return nbytes; 
+}
+
+
+
+
+
+
+/******************************************
+				VIDEO 2
+******************************************/
+
+
+void closeConnection2(int * serverFdWorkVector)
+{
+	closesocket(serverFdWorkVector[0]);
+	return;
+}
+
+
+void initConnection2(int * serverFdWorkVector, int port){
+	int fd = open_TCPserver(port);
+	serverFdWorkVector[0] = fd; 
+	return;
+}
+
+
+double imageReceive2(uint8_t y[153600], int * workFd){
+
+	double nbytes = 0;
+	
+	int fd = accept_TCPserver( (SOCKET) workFd[0]); 
+	nbytes = TCP_receive(fd, y, 153600); 
+	closesocket(fd);
+	
+	return nbytes; 
+}

--- a/AR_Drone_Target/blocks/videolib/tcpWindowsServer.h
+++ b/AR_Drone_Target/blocks/videolib/tcpWindowsServer.h
@@ -1,0 +1,19 @@
+#ifndef _TCP_WINDOWS_SERVER_H
+#define _TCP_WINDOWS_SERVER_H
+
+	#include <stdio.h>
+	#include <stdlib.h>
+	#include <stdint.h>
+	#include <string.h>
+	#include <signal.h>
+	#include<sys/types.h>
+
+	void closeConnection1(int * serverFdWorkVector);
+	void initConnection1(int * serverFdWorkVector, int port);
+	double imageReceive1(uint8_t y[1843200], int * workFd);
+
+	void closeConnection2(int * serverFdWorkVector);
+	void initConnection2(int * serverFdWorkVector, int port);
+	double imageReceive2(uint8_t y[153600], int * workFd);
+	
+#endif

--- a/AR_Drone_Target/ssh_download_video.bat
+++ b/AR_Drone_Target/ssh_download_video.bat
@@ -1,0 +1,67 @@
+@ECHO OFF
+
+SET PLINK_EXE=%~f1\plink.exe
+ECHO "%PLINK_EXE%"
+
+SET PSCP_EXE=%~f1\pscp.exe
+ECHO "%PSCP_EXE%"
+
+SET PASSWORD=%2
+ECHO "%PASSWORD%"
+
+SET USERNAME=%3
+ECHO "%USERNAME%"
+
+SET HOSTNAME=%4
+ECHO "%HOSTNAME%"
+
+SET REMOTE_DIR=%5
+ECHO "%REMOTE_DIR%"
+
+SET EXE_NAME=%~nx6
+ECHO "%EXE_NAME%"
+
+SET EXE_PATH=%~dp6
+ECHO "%EXE_PATH%"
+
+SET NLM=^
+
+SET NL=^^^%NLM%%NLM%^%NLM%%NLM%
+
+ECHO Removing old binaries
+echo killall -9 program.elf.respawner.sh; killall -9 program.elf; killall -9 gst-launch-0.10; killall -9 %EXE_NAME%;  killall -9 gst-launch-0.10; exit > generated_cmds_del.txt
+"%PLINK_EXE%" -telnet -P 23 %HOSTNAME% < generated_cmds_del.txt
+
+ECHO WinSCP FTP Uploading Drone ELF File to port %AR_DRONE_IP_ADDRESS%:5551
+
+echo open ftp://anonymous@%AR_DRONE_IP_ADDRESS%:5551/ -passive=on > %EXE_PATH%upload_script.txt
+echo put "%EXE_PATH%%EXE_NAME%" ./ >> %EXE_PATH%upload_script.txt
+echo put "%EXE_PATH%video_script.sh" ./ >> %EXE_PATH%upload_script.txt
+echo exit >> %EXE_PATH%upload_script.txt
+rem "C:\Program Files (x86)\WinSCP\WinSCP.com" /log="%EXE_PATH%ftp.log" /script="%EXE_PATH%upload_script.txt"
+"C:\Program Files (x86)\WinSCP\WinSCP.com" /script="%EXE_PATH%upload_script.txt"
+
+ECHO Telneting into AR Drone 2.0 and running executable
+
+rem this functions but its annoying, this was the old way, it piped stuff to the diagonstic window
+rem echo cd update;chmod 777 %EXE_NAME%;./%EXE_NAME% | "%PLINK_EXE%" -telnet -P 23 %HOSTNAME% 
+
+ECHO Creating temporary txt file for running commands remotely
+rem echo cd update;chmod 777 %EXE_NAME%; > generated_cmds.txt
+
+echo cd /bin ; ./basescript.sh ; cd /update; chmod 777 video_script.sh; ./video_script.sh; chmod 777 %EXE_NAME%; ./%EXE_NAME% -w > generated_cmds.txt
+
+ECHO Creating temporary batch script for PLINK commands
+echo "%PLINK_EXE%" -telnet -P 23 %HOSTNAME% ^< generated_cmds.txt > generated_batch.bat
+
+ECHO Running model %EXE_NAME% on AR Drone 2.0
+start "AR Drone 2.0 Console Window"  generated_batch.bat
+
+
+
+ECHO Deleting Generated Batch Files
+rem del generated_batch.bat
+rem del generated_cmds.txt
+
+REM [END OF FILE]
+


### PR DESCRIPTION
- Added simple communication TCP blocks for use with original library blocks:
  - TCP client sending the image (Linux - for running on the target drone)
  - TCP server receiving the image (Winows - for running on the host)
- Added new video blocks with merged TCP communication in the code and extended functionalities:
  - Possibility to run an initial cycle to reduce the image delay
  - Possibility of changing the number of frame buffers
- Added new video blocks that use threads (similar to the previous one)

Altered Ardrone_legacy to add compilation for these blocks.
Tested in AR Drone 2.0 (target) / Windows 10 (host) environment
